### PR TITLE
fix: .html is no longer required as starting page for  /boba/{path} r…

### DIFF
--- a/ui/src/pages/_sidebar.js
+++ b/ui/src/pages/_sidebar.js
@@ -15,11 +15,12 @@ const Sidebar = ({selectedKey = 'scenarios'}) => {
     '/storyboard': 'storyboard',
     '/test-strategies': 'tests',
     '/signals': 'company-research',
-    '/saved-ideas': 'saved-ideas'
+    '/saved-ideas': 'saved-ideas',
+    "/chat": "chat",
+    "/threat-modelling": "threat-modelling",
   }
   const router = useRouter()
   const currentSelectedKey = pathToKey[router.pathname];
-
   // TODO: Does this have to change for the "warnKey" and "errorKey" errors to go away?
   // https://ant.design/components/menu#Notes-for-developers
   return (

--- a/ui/src/pages/index.js
+++ b/ui/src/pages/index.js
@@ -93,7 +93,7 @@ export default function Landing() {
           <div className="prompt-example"> ✨ Show me the future of payments 10 years from now</div>
           <div className="prompt-example"> ✨ China becomes the next superpower (optimistic, sci-fi future)</div>
           <br/>
-          <Button type="primary" href="/boba/scenarios.html">Start brainstorming scenarios &gt;</Button>
+          <Button type="primary" href="/boba/scenarios">Start brainstorming scenarios &gt;</Button>
         </Col>
       </Row>
 


### PR DESCRIPTION
Boba pages do not need  urls ending in *.html . Added a middleware to handle /boba/{path} routes, which serves contents fro m {path}.html file. 