### PR TITLE
Creative Matrix: Fix bias for suggesting solution ideas instead of thoughts based on the row/column

### DIFF
--- a/app/shared/boba_api.py
+++ b/app/shared/boba_api.py
@@ -79,13 +79,13 @@ def get_scenarios_prompt(
 
 
 def get_creative_matrix_prompt(rows, columns, prompt, idea_qualifiers, num_ideas):
-    return f"""You are a creative strategist. Given a prompt enclosed in <prompt> below, you will respond to the prompt for each combination/permutation of comma-separated list of rows and columns to generate creative and innovative ideas. Each idea must have a title and description. The idea title must be brief and succinct. Each idea must specifically and directly respond to the prompt. If a company is mentioned in the prompt, make sure you generate ideas specifically for that company. Each idea must be {idea_qualifiers}. You must generate exactly {num_ideas} idea(s) per combination/permutation.
+    return f"""You are a creative strategist. Given a prompt enclosed in <prompt> below, you will respond to the prompt for each combination/permutation of comma-separated list of rows and columns to generate creative and innovative thoughts. Each thought must have a title and description. The thought title must be brief and succinct. Each thought must specifically and directly respond to the prompt. If a company is mentioned in the prompt, make sure you generate thoughts specifically for that company. Each thought must be {idea_qualifiers}. You must generate exactly {num_ideas} thought(s) per combination/permutation.
 
   <prompt>{prompt}</prompt>
   <rows>{rows}</rows>
   <columns>{columns}</columns>
 
-  You will respond with a valid JSON array, by row by column by idea. For example:
+  You will respond with a valid JSON array, by row by column by thought. For example:
 
   If Rows = "row 0, row 1" and Columns = "column 0, column 1" then you will respond with the following:
   [
@@ -96,8 +96,8 @@ def get_creative_matrix_prompt(rows, columns, prompt, idea_qualifiers, num_ideas
           "column": "column 0",
           "ideas": [
             {{
-              "title": "Idea 0 title for prompt and row 0 and column 0",
-              "description": "idea 0 for prompt and row 0 and column 0"
+              "title": "thought 0 title for prompt and row 0 and column 0",
+              "description": "thought 0 for prompt and row 0 and column 0"
             }},
             ...
           ]
@@ -106,8 +106,8 @@ def get_creative_matrix_prompt(rows, columns, prompt, idea_qualifiers, num_ideas
           "column": "column 1",
           "ideas": [
             {{
-              "title": "Idea 0 title for prompt and row 0 and column 1",
-              "description": "idea 0 for prompt and row 0 and column 1"
+              "title": "thought 0 title for prompt and row 0 and column 1",
+              "description": "thought 0 for prompt and row 0 and column 1"
             }},
             ...
           ]
@@ -121,8 +121,8 @@ def get_creative_matrix_prompt(rows, columns, prompt, idea_qualifiers, num_ideas
           "column": "column 0",
           "ideas": [
             {{
-              "title": "Idea 0 title for prompt and row 1 and column 0",
-              "description": "idea 0 for prompt and row 1 and column 0"
+              "title": "thought 0 title for prompt and row 1 and column 0",
+              "description": "thought 0 for prompt and row 1 and column 0"
             }},
             ...
           ]
@@ -131,8 +131,8 @@ def get_creative_matrix_prompt(rows, columns, prompt, idea_qualifiers, num_ideas
           "column": "column 1",
           "ideas": [
             {{
-              "title": "Idea 0 title for prompt and row 1 and column 1",
-              "description": "idea 0 for prompt and row 1 and column 1"
+              "title": "thought 0 title for prompt and row 1 and column 1",
+              "description": "thought 0 for prompt and row 1 and column 1"
             }},
             ...
           ]
@@ -141,7 +141,7 @@ def get_creative_matrix_prompt(rows, columns, prompt, idea_qualifiers, num_ideas
     }}
   ]
 
-  Remember that each idea must be {idea_qualifiers}. Remember you mnust generate exactly {num_ideas} idea(s) per combination/permutation.
+  Remember that each thought must be {idea_qualifiers}. Remember you mnust generate exactly {num_ideas} thought(s) per combination/permutation.
 
 """
 


### PR DESCRIPTION
Useful for generating things like jobs, pains and gains. This fix involves rewording the prompt to suggesting 'thoughts' instead of 'ideas'.