### PR TITLE
feat: add support for OpenAI provider in ModelConfig to set lite_id using model_name

### DIFF
--- a/app/llms/model_config.py
+++ b/app/llms/model_config.py
@@ -36,6 +36,8 @@ class ModelConfig:
             self.lite_id = "bedrock/" + self.config["model_id"]
         elif self.provider.lower() == "anthropic":
             self.lite_id = "anthropic/" + self.config["model_id"]
+        elif self.provider.lower() == "openai":
+            self.lite_id = "openai/" + self.config["model_name"]
         elif self.provider.lower() == "gcp":
             self.lite_id = "gemini/" + self.config["model"]
         elif self.provider.lower() == "ollama":


### PR DESCRIPTION
Signed-off-by: Emmanuel Auffray <emmanuel.auffray@gmail.com>


just pointing out that openai litellm wrapper needs the lite_id set if provider is openai