### PR TITLE
Prompts display structure

### DIFF
--- a/ui/src/__tests__/_knowledge_overview_prompts.test.js
+++ b/ui/src/__tests__/_knowledge_overview_prompts.test.js
@@ -1,0 +1,54 @@
+// © 2024 Thoughtworks, Inc. | Licensed under the Apache License, Version 2.0  | See LICENSE.md file for permissions.
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import KnowledgePackPage from "../pages/knowledge";
+import "@testing-library/jest-dom";
+
+describe("Knowledge overview prompts section", () => {
+  const prompts = [
+    {
+      identifier: "architecture-prompt",
+      title: "Architecture Prompt",
+      categories: ["architecture"],
+      help_prompt_description: "Architecture prompt description",
+      download_restricted: false,
+    },
+    {
+      identifier: "coding-prompt",
+      title: "Coding Prompt",
+      categories: ["coding"],
+      help_prompt_description: "Coding prompt description",
+      download_restricted: false,
+    },
+  ];
+
+  const renderKnowledgePage = (featureToggleConfig = {}) =>
+    render(
+      <KnowledgePackPage
+        contexts={[]}
+        documents={[]}
+        prompts={prompts}
+        rules={[]}
+        featureToggleConfig={featureToggleConfig}
+      />,
+    );
+
+  it("shows prompt categories with per-prompt actions", async () => {
+    renderKnowledgePage();
+
+    expect(screen.getByText("Prompts")).toBeInTheDocument();
+    expect(screen.getByText("Architecture")).toBeInTheDocument();
+    expect(screen.getByText("Coding")).toBeInTheDocument();
+
+    expect(
+      screen.getByTestId("download-category-architecture"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("download-category-coding")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Architecture"));
+
+    expect(screen.getByText("Architecture Prompt")).toBeInTheDocument();
+    expect(screen.getByTestId("prompt-preview-button")).toBeInTheDocument();
+    expect(screen.getByTestId("download-prompt-button")).toBeInTheDocument();
+  });
+});

--- a/ui/src/__tests__/_knowledge_overview_prompts.test.js
+++ b/ui/src/__tests__/_knowledge_overview_prompts.test.js
@@ -48,7 +48,11 @@ describe("Knowledge overview prompts section", () => {
     fireEvent.click(screen.getByText("Architecture"));
 
     expect(screen.getByText("Architecture Prompt")).toBeInTheDocument();
-    expect(screen.getByTestId("prompt-preview-button")).toBeInTheDocument();
-    expect(screen.getByTestId("download-prompt-button")).toBeInTheDocument();
+    expect(screen.getAllByTestId("prompt-preview-button").length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getAllByTestId("download-prompt-button").length).toBeGreaterThan(
+      0,
+    );
   });
 });

--- a/ui/src/app/_download_prompt_category.js
+++ b/ui/src/app/_download_prompt_category.js
@@ -1,0 +1,59 @@
+// © 2024 Thoughtworks, Inc. | Licensed under the Apache License, Version 2.0  | See LICENSE.md file for permissions.
+import { Tooltip } from "antd";
+import { RiDownload2Line } from "react-icons/ri";
+import JSZip from "jszip";
+import { fetchAllPromptsContents } from "./utils/promptDownloadUtils";
+
+const DownloadPromptCategory = ({ category, label }) => {
+  const handleCategoryDownload = async (event) => {
+    event.stopPropagation();
+    if (!category) return;
+
+    const folderName =
+      category.toLowerCase().replace(/\s+/g, "-") + "-prompts";
+
+    try {
+      const zip = new JSZip();
+      const categoryFolder = zip.folder(folderName);
+      const promptContents = await fetchAllPromptsContents(category);
+
+      promptContents.forEach((prompt) => {
+        categoryFolder.file(prompt.filename, prompt.content);
+      });
+
+      const content = await zip.generateAsync({ type: "blob" });
+      const url = URL.createObjectURL(content);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `${folderName}.zip`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error("Error downloading prompt category:", error);
+    }
+  };
+
+  if (!category) {
+    return null;
+  }
+
+  const displayLabel =
+    typeof label === "string" && label.trim().length > 0 ? label : category;
+
+  return (
+    <Tooltip title={`Download ${displayLabel} prompts`} placement="bottom">
+      <button
+        className="download-prompt-button"
+        data-testid={`download-category-${category}`}
+        onClick={handleCategoryDownload}
+        type="button"
+      >
+        <RiDownload2Line />
+      </button>
+    </Tooltip>
+  );
+};
+
+export default DownloadPromptCategory;

--- a/ui/src/app/_prompt_overview_preview.js
+++ b/ui/src/app/_prompt_overview_preview.js
@@ -1,0 +1,67 @@
+// © 2024 Thoughtworks, Inc. | Licensed under the Apache License, Version 2.0  | See LICENSE.md file for permissions.
+import { useState } from "react";
+import { Modal, Tooltip, message } from "antd";
+import { RiEyeLine } from "react-icons/ri";
+import { fetchPromptContent } from "./utils/promptDownloadUtils";
+
+const PromptOverviewPreview = ({ prompt }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [previewContent, setPreviewContent] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handlePreview = async (event) => {
+    event.stopPropagation();
+    if (!prompt) return;
+
+    setIsOpen(true);
+
+    if (previewContent) return;
+
+    setIsLoading(true);
+    try {
+      const downloadablePrompt = await fetchPromptContent(prompt);
+      setPreviewContent(downloadablePrompt.content);
+    } catch (error) {
+      console.error("Error previewing prompt:", error);
+      setPreviewContent("Preview is not available for this prompt.");
+      message.error("Failed to load prompt preview.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!prompt) {
+    return null;
+  }
+
+  return (
+    <>
+      <Tooltip title="Preview Prompt" placement="bottom">
+        <button
+          className="download-prompt-button"
+          data-testid="prompt-preview-button"
+          onClick={handlePreview}
+          type="button"
+        >
+          <RiEyeLine />
+        </button>
+      </Tooltip>
+      <Modal
+        title={prompt.title || "Prompt Preview"}
+        open={isOpen}
+        onCancel={() => setIsOpen(false)}
+        footer={null}
+      >
+        <div className="snippet">
+          {isLoading ? (
+            <p>Loading prompt preview...</p>
+          ) : (
+            <pre>{previewContent}</pre>
+          )}
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+export default PromptOverviewPreview;

--- a/ui/src/app/utils/promptGroupingUtils.js
+++ b/ui/src/app/utils/promptGroupingUtils.js
@@ -1,0 +1,67 @@
+// © 2024 Thoughtworks, Inc. | Licensed under the Apache License, Version 2.0  | See LICENSE.md file for permissions.
+import {
+  initialiseMenuCategoriesForSidebar,
+  THOUGHTWORKS_ONLY_CATEGORIES,
+} from "../_navigation_items";
+import { FEATURES } from "../feature_toggle";
+
+const isThoughtworksPrompt = (prompt) =>
+  prompt.categories?.some((category) =>
+    THOUGHTWORKS_ONLY_CATEGORIES.includes(category),
+  );
+
+export const buildPromptCategories = (prompts = [], featureToggleConfig = {}) => {
+  const isThoughtworksInstance =
+    featureToggleConfig?.[FEATURES.THOUGHTWORKS] === true;
+  const menuCategories = initialiseMenuCategoriesForSidebar(
+    isThoughtworksInstance,
+  );
+
+  const promptsByCategory = {};
+
+  prompts
+    .filter((prompt) => prompt.show !== false)
+    .filter((prompt) => {
+      if (isThoughtworksPrompt(prompt)) {
+        return isThoughtworksInstance;
+      }
+      return true;
+    })
+    .forEach((prompt) => {
+      const promptCategories =
+        prompt.categories && prompt.categories.length > 0
+          ? prompt.categories
+          : ["other"];
+
+      promptCategories.forEach((category) => {
+        if (
+          THOUGHTWORKS_ONLY_CATEGORIES.includes(category) &&
+          !isThoughtworksInstance
+        ) {
+          return;
+        }
+
+        const categoryKey = menuCategories[category] ? category : "other";
+        if (!promptsByCategory[categoryKey]) {
+          promptsByCategory[categoryKey] = [];
+        }
+        promptsByCategory[categoryKey].push(prompt);
+      });
+    });
+
+  return Object.keys(menuCategories)
+    .filter((key) => {
+      const menuCategory = menuCategories[key];
+      if (menuCategory.type === "divider" || menuCategory.type === "group") {
+        return false;
+      }
+      return promptsByCategory[key] && promptsByCategory[key].length > 0;
+    })
+    .map((key) => ({
+      key,
+      label: menuCategories[key].label,
+      prompts: promptsByCategory[key].slice().sort((a, b) => {
+        return (a.title || "").localeCompare(b.title || "");
+      }),
+    }));
+};


### PR DESCRIPTION
Hi, thanks for creating a pull request!

Please note that unfortunately, we are currently not set up to take pull requests from people not employed by Thoughtworks. 

If you are working at Thoughtworks:

- If you are already a member of the "haiven" GitHub organization, feel free to create this pull request.
- If you are not a member of the "haiven" GitHub organization yet, request access via the form linked on our [Central page](https://central.thoughtworks.net/home/team-assistance-accelerator) before you create the pull request.
- Join us in the "Haiven - Community" chat space to find out the latest about our contribution process.

Redesigns the prompts section on the knowledge overview page to provide a structured, categorized display with collapsible sections, similar to the existing documents section. This enhances prompt discoverability and management by offering per-prompt preview and download options, as well as category-level downloads. The implementation reuses existing styling and prompt grouping logic for consistency.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-c371b570-13a0-4b3e-a019-c420f301317c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c371b570-13a0-4b3e-a019-c420f301317c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

